### PR TITLE
Fixed error.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,9 @@
 site_name: Keras Documentation
-# theme: readthedocs
+theme: readthedocs
 docs_dir: sources
 repo_url: http://github.com/fchollet/keras
 site_url: http://keras.io/
-theme_dir: ../keras/docs/theme
+# theme_dir: ../keras/docs/theme
 site_description: 'Documentation for Keras, the Python Deep Learning library.'
 
 dev_addr: '0.0.0.0:8000'


### PR DESCRIPTION
Fixed the following error occurred at `mkdocs build` command execution.
"ERROR   -  Config value: 'theme_dir'. Error: The path ../keras/docs/theme doesn't exist"