### PR TITLE
Fix translation of getting started

### DIFF
--- a/sources/getting-started/functional-api-guide.md
+++ b/sources/getting-started/functional-api-guide.md
@@ -293,7 +293,7 @@ assert conv.get_input_shape_at(1) == (None, 64, 64, 3)
 
 ## More examples
 
-コード例から学び始めることは最良の手法です。
+コード例から学び始めることは最良の手法です.
 その他の例も見てみましょう．
 
 ### Inception module

--- a/sources/getting-started/functional-api-guide.md
+++ b/sources/getting-started/functional-api-guide.md
@@ -293,7 +293,7 @@ assert conv.get_input_shape_at(1) == (None, 64, 64, 3)
 
 ## More examples
 
-コード例を見ることは訓練時に非常に有効です．
+コード例から学び始めることは最良の手法です。
 その他の例も見てみましょう．
 
 ### Inception module


### PR DESCRIPTION
I have fixed mistranslation of `get started`.

https://github.com/keras-team/keras/blob/8b5cc7fff1df3f7295fa12a4036a64c0f21f9150/docs/templates/getting-started/functional-api-guide.md

Probably it is due to the replacement of `学習` with `訓練`.
https://github.com/keras-team/keras-docs-ja/commit/0de707f30dc534b071b00ff1c8e238089d56c2ab