### PR TITLE
Fix sequential model guid

### DIFF
--- a/sources/getting-started/sequential-model-guide.md
+++ b/sources/getting-started/sequential-model-guide.md
@@ -152,6 +152,7 @@ model.fit(data, one_hot_labels, epochs=10, batch_size=32)
 ### 多層パーセプトロン (MLP) を用いた多値分類:
 
 ```python
+import keras
 from keras.models import Sequential
 from keras.layers import Dense, Dropout, Activation
 from keras.optimizers import SGD

--- a/sources/getting-started/sequential-model-guide.md
+++ b/sources/getting-started/sequential-model-guide.md
@@ -152,6 +152,7 @@ model.fit(data, one_hot_labels, epochs=10, batch_size=32)
 ### 多層パーセプトロン (MLP) を用いた多値分類:
 
 ```python
+from keras.utils import to_categorical
 from keras.models import Sequential
 from keras.layers import Dense, Dropout, Activation
 from keras.optimizers import SGD
@@ -159,9 +160,9 @@ from keras.optimizers import SGD
 # ダミーデータ生成
 import numpy as np
 x_train = np.random.random((1000, 20))
-y_train = keras.utils.to_categorical(np.random.randint(10, size=(1000, 1)), num_classes=10)
+y_train = to_categorical(np.random.randint(10, size=(1000, 1)), num_classes=10)
 x_test = np.random.random((100, 20))
-y_test = keras.utils.to_categorical(np.random.randint(10, size=(100, 1)), num_classes=10)
+y_test = to_categorical(np.random.randint(10, size=(100, 1)), num_classes=10)
 
 model = Sequential()
 # Dense(64) は，64個のhidden unitを持つ全結合層です．

--- a/sources/getting-started/sequential-model-guide.md
+++ b/sources/getting-started/sequential-model-guide.md
@@ -152,7 +152,6 @@ model.fit(data, one_hot_labels, epochs=10, batch_size=32)
 ### 多層パーセプトロン (MLP) を用いた多値分類:
 
 ```python
-from keras.utils import to_categorical
 from keras.models import Sequential
 from keras.layers import Dense, Dropout, Activation
 from keras.optimizers import SGD
@@ -160,9 +159,9 @@ from keras.optimizers import SGD
 # ダミーデータ生成
 import numpy as np
 x_train = np.random.random((1000, 20))
-y_train = to_categorical(np.random.randint(10, size=(1000, 1)), num_classes=10)
+y_train = keras.utils.to_categorical(np.random.randint(10, size=(1000, 1)), num_classes=10)
 x_test = np.random.random((100, 20))
-y_test = to_categorical(np.random.randint(10, size=(100, 1)), num_classes=10)
+y_test = keras.utils.to_categorical(np.random.randint(10, size=(100, 1)), num_classes=10)
 
 model = Sequential()
 # Dense(64) は，64個のhidden unitを持つ全結合層です．


### PR DESCRIPTION
I executed this code.
```python
from keras.models import Sequential
from keras.layers import Dense, Dropout, Activation
from keras.optimizers import SGD

# ダミーデータ生成
import numpy as np
x_train = np.random.random((1000, 20))
y_train = keras.utils.to_categorical(np.random.randint(10, size=(1000, 1)), num_classes=10)
x_test = np.random.random((100, 20))
y_test = keras.utils.to_categorical(np.random.randint(10, size=(100, 1)), num_classes=10)

model = Sequential()
# Dense(64) は，64個のhidden unitを持つ全結合層です．
# 最初のlayerでは，想定する入力データshapeを指定する必要があり，ここでは20次元としてます．
model.add(Dense(64, activation='relu', input_dim=20))
model.add(Dropout(0.5))
model.add(Dense(64, activation='relu'))
model.add(Dropout(0.5))
model.add(Dense(10, activation='softmax'))

sgd = SGD(lr=0.01, decay=1e-6, momentum=0.9, nesterov=True)
model.compile(loss='categorical_crossentropy',
              optimizer=sgd,
              metrics=['accuracy'])

model.fit(x_train, y_train,
          epochs=20,
          batch_size=128)
score = model.evaluate(x_test, y_test, batch_size=128)
```

but I got this error message and didn't execute.
`NameError: name 'keras' is not defined`

I added import code  in this pull request