### PR TITLE
core.md内のスペルミス修正

### DIFF
--- a/sources/layers/core.md
+++ b/sources/layers/core.md
@@ -49,7 +49,7 @@ __入力のshape__
 __出力のshape__
 
 以下のshapeを持つn階テンソル： `(batch_size, ..., units)`．
-例えば，以下のshapeを持つ2階テンソル `(batch_size, input_dim)`の入力に対して，アウトプットは以下のshapwを持つ`(batch_size, units)`．
+例えば，以下のshapeを持つ2階テンソル `(batch_size, input_dim)`の入力に対して，アウトプットは以下のshapeを持つ`(batch_size, units)`．
 
 ----
 


### PR DESCRIPTION
日本語ドキュメントの修正です。
core.md内のDenseの説明の52行目のshapeの部分がshapwになっていました。
初心者の方が見たときに理解に間違えが無いように、修正してみたのですがいかがでしょうか？

shapw => shape